### PR TITLE
BUG: Fixed indexing error when using bounds with Powell's method in scipy.optimize.minimize

### DIFF
--- a/scipy/optimize/optimize.py
+++ b/scipy/optimize/optimize.py
@@ -2912,7 +2912,7 @@ def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
         lower_bound, upper_bound = None, None
     else:
         # bounds is standardized in _minimize.py.
-        lower_bound, upper_bound = bounds.lb, bounds.ub
+        lower_bound, upper_bound = np.asarray(bounds.lb), np.asarray(bounds.ub)
         if np.any(lower_bound > x0) or np.any(x0 > upper_bound):
             warnings.warn("Initial guess is not within the specified bounds",
                           OptimizeWarning, 3)


### PR DESCRIPTION
#### What does this implement/fix?
Using bound constraints in  `scipy.optimize.minimize` with Powell's method was introduced with scipy 1.15.0. It uses the `scipy.optimize.Bounds` class to define the lower and upper bounds for each variable. \
`Bounds` accepts any array-like as `ub` and `lb` and performs no conversion, therefore it is possible to use lists as upper and lower bounds, which are then passed on to `_linesearch_powell` and `_line_for_search`. Since `_line_for_search` extracts the bounds for every non-zero variable using the result of np.nonzero as an index, which does not work on lists, this produces an error when the bounds are defined as lists instead of np.array. The following MWE produces this error:
```python
import scipy.optimize

def f(x):
    return x[0]**2 + (x[1] - 1)**2

bounds = scipy.optimize.Bounds(lb=[-10, -10], ub=[10, 10])
scipy.optimize.minimize(f, x0=(0,0), method='Powell', bounds=bounds)
```
This can be fixed by making sure `_line_for_search` gets `lower_bound` and `upper_bound` as type np.array as specified by the docstring. I added `np.asarray` where the two bounds are extracted from the `Bounds` object, since it only happens once for each call to minimize. If there is a better place to fix this, please tell me.
#### Additional information
This is my first pull request, so please tell me if I forgot something or did something the wrong way.